### PR TITLE
Add FUNDING file

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,2 @@
+open_collective: php_codesniffer
+github: [PHPCompatibility, jrfnl]


### PR DESCRIPTION
The PHPCompatibility organisation has been approved for the GH sponsors program, so let's get it to display a sponsor button on all repos.

Ref:
* https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository